### PR TITLE
Refactor crawler traits and reduce main duplication

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use crate::{
     response_processor::{
         app_store::AppStoreReview, play_store::PlayStoreReview, RawResponse, ResponseProcessor,
     },
-    review_crawler::Crawler,
+    review_crawler::{Crawler, traits::{HasAppInfo, TBuildRequest}},
     target_app::load_target_apps,
 };
 
@@ -15,6 +15,58 @@ mod target_app;
 
 const TARGET_APPS_PATH: &str = "target_apps.json";
 const OUTPUT_PATH: &str = "output";
+
+async fn run_store_crawler<C, D, F>(store_name: &str, apps: Vec<C>, make_extractor: F)
+where
+    C: TBuildRequest + HasAppInfo + Clone + Send + 'static,
+    D: response_processor::traits::TExtractData
+        + response_processor::traits::TStoreType
+        + Send
+        + 'static,
+    F: Fn() -> D,
+{
+    println!("[INFO] Starting {} crawler task", store_name);
+    println!("[INFO] Found {} {} apps to crawl", apps.len(), store_name);
+
+    for (i, app) in apps.iter().enumerate() {
+        println!(
+            "[INFO] Crawling {} app {}/{}: {} (country: {})",
+            store_name,
+            i + 1,
+            apps.len(),
+            app.app_id(),
+            app.country()
+        );
+
+        let app_id = app.app_id().to_string();
+        let mut crawler = Crawler::new(app.clone());
+
+        match crawler.run().await {
+            Ok(response) => {
+                println!("[INFO] Successfully got response for app: {}", app_id);
+                let processor: ResponseProcessor<D> = ResponseProcessor::new(
+                    RawResponse::new(response),
+                    make_extractor(),
+                    app_id.clone(),
+                );
+
+                match processor.run().await {
+                    Ok(_) => println!(
+                        "[INFO] Successfully processed and saved reviews for app: {}",
+                        app_id
+                    ),
+                    Err(e) => println!(
+                        "[ERROR] Failed to process reviews for app {}: {}",
+                        app_id, e
+                    ),
+                }
+            }
+            Err(e) => {
+                println!("[ERROR] Failed to crawl app {}: {}", app_id, e);
+            }
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() {
@@ -32,97 +84,13 @@ async fn main() {
     };
 
     task::spawn(async move {
-        println!("[INFO] Starting App Store crawler task");
-        let app_store_apps = target_apps.app_store_apps.read().await.clone();
-        println!(
-            "[INFO] Found {} App Store apps to crawl",
-            app_store_apps.len()
-        );
-
-        for (i, app) in app_store_apps.iter().enumerate() {
-            println!(
-                "[INFO] Crawling App Store app {}/{}: {} (country: {})",
-                i + 1,
-                app_store_apps.len(),
-                app.app_id,
-                app.country
-            );
-
-            let app_id = app.app_id.clone();
-            let mut crawler = Crawler::new(app.clone());
-
-            match crawler.run().await {
-                Ok(response) => {
-                    println!("[INFO] Successfully got response for app: {}", app_id);
-                    let processor: ResponseProcessor<AppStoreReview> = ResponseProcessor::new(
-                        RawResponse::new(response),
-                        AppStoreReview::new(),
-                        app_id.clone(),
-                    );
-
-                    match processor.run().await {
-                        Ok(_) => println!(
-                            "[INFO] Successfully processed and saved reviews for app: {}",
-                            app_id
-                        ),
-                        Err(e) => println!(
-                            "[ERROR] Failed to process reviews for app {}: {}",
-                            app_id, e
-                        ),
-                    }
-                }
-                Err(e) => {
-                    println!("[ERROR] Failed to crawl app {}: {}", app_id, e);
-                }
-            }
-        }
+        let apps = target_apps.app_store_apps.read().await.clone();
+        run_store_crawler("App Store", apps, AppStoreReview::new).await;
     });
 
     task::spawn(async move {
-        println!("[INFO] Starting Play Store crawler task");
-        let play_store_apps = target_apps.play_store_apps.read().await.clone();
-        println!(
-            "[INFO] Found {} Play Store apps to crawl",
-            play_store_apps.len()
-        );
-
-        for (i, app) in play_store_apps.iter().enumerate() {
-            println!(
-                "[INFO] Crawling Play Store app {}/{}: {} (country: {})",
-                i + 1,
-                play_store_apps.len(),
-                app.app_id,
-                app.country
-            );
-
-            let app_id = app.app_id.clone();
-            let mut crawler = Crawler::new(app.clone());
-
-            match crawler.run().await {
-                Ok(response) => {
-                    println!("[INFO] Successfully got response for app: {}", app_id);
-                    let processor: ResponseProcessor<PlayStoreReview> = ResponseProcessor::new(
-                        RawResponse::new(response),
-                        PlayStoreReview::new(),
-                        app_id.clone(),
-                    );
-
-                    match processor.run().await {
-                        Ok(_) => println!(
-                            "[INFO] Successfully processed and saved reviews for app: {}",
-                            app_id
-                        ),
-                        Err(e) => println!(
-                            "[ERROR] Failed to process reviews for app {}: {}",
-                            app_id, e
-                        ),
-                    }
-                }
-                Err(e) => {
-                    println!("[ERROR] Failed to crawl app {}: {}", app_id, e);
-                }
-            }
-        }
+        let apps = target_apps.play_store_apps.read().await.clone();
+        run_store_crawler("Play Store", apps, PlayStoreReview::new).await;
     });
 
     // 메인 스레드가 종료되지 않도록 잠시 대기

--- a/src/review_crawler/app_store.rs
+++ b/src/review_crawler/app_store.rs
@@ -1,7 +1,7 @@
 use reqwest::RequestBuilder;
 use serde::{Deserialize, Serialize};
 
-use crate::review_crawler::{get_client, traits::TBuildReqeust};
+use crate::review_crawler::{get_client, HasAppInfo, TBuildRequest};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppStoreClient {
@@ -11,7 +11,17 @@ pub struct AppStoreClient {
     pub pages: u32,
 }
 
-impl TBuildReqeust for AppStoreClient {
+impl HasAppInfo for AppStoreClient {
+    fn app_id(&self) -> &str {
+        &self.app_id
+    }
+
+    fn country(&self) -> &str {
+        &self.country
+    }
+}
+
+impl TBuildRequest for AppStoreClient {
     fn build_request(&mut self) -> RequestBuilder {
         get_client().get(format!(
             "https://itunes.apple.com/{}/rss/customerreviews/id={}/page={}/sortby=mostrecent/xml",

--- a/src/review_crawler/mod.rs
+++ b/src/review_crawler/mod.rs
@@ -2,17 +2,18 @@ use std::sync::OnceLock;
 
 use reqwest::{Client, Response};
 
-use crate::{errors::CrawlerError, review_crawler::traits::TBuildReqeust};
+use crate::errors::CrawlerError;
 
 pub mod app_store;
 pub mod play_store;
-mod traits;
+pub mod traits;
+pub use traits::{HasAppInfo, TBuildRequest};
 
-pub struct Crawler<C: TBuildReqeust> {
+pub struct Crawler<C: TBuildRequest> {
     client: C,
 }
 
-impl<C: TBuildReqeust> Crawler<C> {
+impl<C: TBuildRequest> Crawler<C> {
     pub fn new(client: C) -> Self {
         Self { client }
     }

--- a/src/review_crawler/play_store.rs
+++ b/src/review_crawler/play_store.rs
@@ -1,7 +1,7 @@
 use reqwest::RequestBuilder;
 use serde::{Deserialize, Serialize};
 
-use crate::review_crawler::{get_client, traits::TBuildReqeust};
+use crate::review_crawler::{get_client, HasAppInfo, TBuildRequest};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlayStoreClient {
@@ -11,7 +11,17 @@ pub struct PlayStoreClient {
     pub pages: u32,
 }
 
-impl TBuildReqeust for PlayStoreClient {
+impl HasAppInfo for PlayStoreClient {
+    fn app_id(&self) -> &str {
+        &self.app_id
+    }
+
+    fn country(&self) -> &str {
+        &self.country
+    }
+}
+
+impl TBuildRequest for PlayStoreClient {
     fn build_request(&mut self) -> RequestBuilder {
         // Play Store API endpoint (placeholder - needs actual implementation)
         get_client()

--- a/src/review_crawler/traits.rs
+++ b/src/review_crawler/traits.rs
@@ -1,8 +1,13 @@
 use reqwest::RequestBuilder;
 
-pub trait TBuildReqeust {
+pub trait TBuildRequest {
     fn build_request(&mut self) -> RequestBuilder;
     fn has_more_pages(&self) -> bool;
     fn increment_page(&mut self);
     fn get_current_page(&self) -> u32;
+}
+
+pub trait HasAppInfo {
+    fn app_id(&self) -> &str;
+    fn country(&self) -> &str;
 }


### PR DESCRIPTION
## Summary
- rename `TBuildReqeust` to `TBuildRequest`
- expose `TBuildRequest` and new `HasAppInfo` trait
- implement `HasAppInfo` for clients
- add generic `run_store_crawler` to remove duplicated crawling code
- update imports and usage throughout

## Testing
- `cargo test`