### PR TITLE
refactor: improve XML parsing code readability and reduce duplication

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,10 @@ use crate::{
     response_processor::{
         app_store::AppStoreReview, play_store::PlayStoreReview, RawResponse, ResponseProcessor,
     },
-    review_crawler::Crawler,
+    review_crawler::{
+        traits::{HasAppInfo, TBuildRequest},
+        Crawler,
+    },
     target_app::load_target_apps,
 };
 
@@ -15,6 +18,60 @@ mod target_app;
 
 const TARGET_APPS_PATH: &str = "target_apps.json";
 const OUTPUT_PATH: &str = "output";
+const APP_STORE_MAX_PAGES: u32 = 10;
+const GOOGLE_PLAY_MAX_PAGES: u32 = 100;
+
+async fn run_store_crawler<C, D, F>(store_name: &str, apps: Vec<C>, make_extractor: F)
+where
+    C: TBuildRequest + HasAppInfo + Clone + Send + 'static,
+    D: response_processor::traits::TExtractData
+        + response_processor::traits::TStoreType
+        + Send
+        + 'static,
+    F: Fn() -> D,
+{
+    println!("[INFO] Starting {} crawler task", store_name);
+    println!("[INFO] Found {} {} apps to crawl", apps.len(), store_name);
+
+    for (i, app) in apps.iter().enumerate() {
+        println!(
+            "[INFO] Crawling {} app {}/{}: {} (country: {})",
+            store_name,
+            i + 1,
+            apps.len(),
+            app.app_id(),
+            app.country()
+        );
+
+        let app_id = app.app_id().to_string();
+        let mut crawler = Crawler::new(app.clone());
+
+        match crawler.run().await {
+            Ok(response) => {
+                println!("[INFO] Successfully got response for app: {}", app_id);
+                let processor: ResponseProcessor<D> = ResponseProcessor::new(
+                    RawResponse::new(response),
+                    make_extractor(),
+                    app_id.clone(),
+                );
+
+                match processor.run().await {
+                    Ok(_) => println!(
+                        "[INFO] Successfully processed and saved reviews for app: {}",
+                        app_id
+                    ),
+                    Err(e) => println!(
+                        "[ERROR] Failed to process reviews for app {}: {}",
+                        app_id, e
+                    ),
+                }
+            }
+            Err(e) => {
+                println!("[ERROR] Failed to crawl app {}: {}", app_id, e);
+            }
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() {
@@ -32,97 +89,13 @@ async fn main() {
     };
 
     task::spawn(async move {
-        println!("[INFO] Starting App Store crawler task");
-        let app_store_apps = target_apps.app_store_apps.read().await.clone();
-        println!(
-            "[INFO] Found {} App Store apps to crawl",
-            app_store_apps.len()
-        );
-
-        for (i, app) in app_store_apps.iter().enumerate() {
-            println!(
-                "[INFO] Crawling App Store app {}/{}: {} (country: {})",
-                i + 1,
-                app_store_apps.len(),
-                app.app_id,
-                app.country
-            );
-
-            let app_id = app.app_id.clone();
-            let mut crawler = Crawler::new(app.clone());
-
-            match crawler.run().await {
-                Ok(response) => {
-                    println!("[INFO] Successfully got response for app: {}", app_id);
-                    let processor: ResponseProcessor<AppStoreReview> = ResponseProcessor::new(
-                        RawResponse::new(response),
-                        AppStoreReview::new(),
-                        app_id.clone(),
-                    );
-
-                    match processor.run().await {
-                        Ok(_) => println!(
-                            "[INFO] Successfully processed and saved reviews for app: {}",
-                            app_id
-                        ),
-                        Err(e) => println!(
-                            "[ERROR] Failed to process reviews for app {}: {}",
-                            app_id, e
-                        ),
-                    }
-                }
-                Err(e) => {
-                    println!("[ERROR] Failed to crawl app {}: {}", app_id, e);
-                }
-            }
-        }
+        let apps = target_apps.app_store_apps.read().await.clone();
+        run_store_crawler("App Store", apps, AppStoreReview::new).await;
     });
 
     task::spawn(async move {
-        println!("[INFO] Starting Play Store crawler task");
-        let play_store_apps = target_apps.play_store_apps.read().await.clone();
-        println!(
-            "[INFO] Found {} Play Store apps to crawl",
-            play_store_apps.len()
-        );
-
-        for (i, app) in play_store_apps.iter().enumerate() {
-            println!(
-                "[INFO] Crawling Play Store app {}/{}: {} (country: {})",
-                i + 1,
-                play_store_apps.len(),
-                app.app_id,
-                app.country
-            );
-
-            let app_id = app.app_id.clone();
-            let mut crawler = Crawler::new(app.clone());
-
-            match crawler.run().await {
-                Ok(response) => {
-                    println!("[INFO] Successfully got response for app: {}", app_id);
-                    let processor: ResponseProcessor<PlayStoreReview> = ResponseProcessor::new(
-                        RawResponse::new(response),
-                        PlayStoreReview::new(),
-                        app_id.clone(),
-                    );
-
-                    match processor.run().await {
-                        Ok(_) => println!(
-                            "[INFO] Successfully processed and saved reviews for app: {}",
-                            app_id
-                        ),
-                        Err(e) => println!(
-                            "[ERROR] Failed to process reviews for app {}: {}",
-                            app_id, e
-                        ),
-                    }
-                }
-                Err(e) => {
-                    println!("[ERROR] Failed to crawl app {}: {}", app_id, e);
-                }
-            }
-        }
+        let apps = target_apps.play_store_apps.read().await.clone();
+        run_store_crawler("Play Store", apps, PlayStoreReview::new).await;
     });
 
     // 메인 스레드가 종료되지 않도록 잠시 대기

--- a/src/response_processor/app_store.rs
+++ b/src/response_processor/app_store.rs
@@ -56,58 +56,13 @@ impl TExtractData for AppStoreReview {
         loop {
             match reader.read_event() {
                 Ok(Event::Start(ref e)) => {
-                    match e.name() {
-                        QName(b"entry") => {
-                            in_entry = true;
-                            current = AppStoreReview::new();
-                            println!("[DEBUG] Enter <entry>");
-                        }
-                        QName(b"title") if in_entry => {
-                            if let Ok(txt) = reader.read_text(e.name()) {
-                                current.title = txt.to_string();
-                            }
-                        }
-                        QName(b"content") if in_entry => {
-                            // type="text"인 content만
-                            if let Some(Attribute { key: _, value: _ }) =
-                                e.attributes().filter_map(Result::ok).find(|attr| {
-                                    attr.key == QName(b"type") && attr.value.as_ref() == b"text"
-                                })
-                            {
-                                if let Ok(txt) = reader.read_text(e.name()) {
-                                    current.review = txt.to_string();
-                                }
-                            }
-                        }
-                        QName(b"im:rating") if in_entry => {
-                            if let Ok(txt) = reader.read_text(e.name()) {
-                                current.star = txt.parse().unwrap_or(0);
-                            }
-                        }
-                        QName(b"im:voteSum") if in_entry => {
-                            if let Ok(txt) = reader.read_text(e.name()) {
-                                current.like = txt.parse().unwrap_or(0);
-                            }
-                        }
-                        QName(b"im:voteCount") if in_entry => {
-                            if let Ok(txt) = reader.read_text(e.name()) {
-                                let total: i32 = txt.parse().unwrap_or(0);
-                                current.dislike = total.saturating_sub(current.like);
-                            }
-                        }
-                        QName(b"updated") if in_entry => {
-                            if let Ok(txt) = reader.read_text(e.name()) {
-                                current.date = txt.to_string();
-                            }
-                        }
-                        _ => {}
-                    }
+                    Self::handle_start_event(e, &mut reader, &mut current, &mut in_entry);
                 }
 
                 Ok(Event::End(ref e)) if e.name() == QName(b"entry") => {
-                    // entry가 끝나면 완성된 리뷰를 저장
+                    // push the completed review
                     println!("[DEBUG] Exit </entry>: {:?}", current);
-                    // 필수 필드(title, review)가 있으면 푸쉬
+                    // if the required fields (title, review) are present, push
                     if !current.title.is_empty() && !current.review.is_empty() {
                         reviews.push(current.clone());
                     } else {
@@ -135,6 +90,76 @@ impl TExtractData for AppStoreReview {
         }
 
         Ok(reviews)
+    }
+}
+
+impl AppStoreReview {
+    fn handle_start_event(
+        e: &quick_xml::events::BytesStart,
+        reader: &mut Reader<&[u8]>,
+        current: &mut AppStoreReview,
+        in_entry: &mut bool,
+    ) {
+        match e.name() {
+            QName(b"entry") => {
+                *in_entry = true;
+                *current = AppStoreReview::new();
+                println!("[DEBUG] Enter <entry>");
+            }
+            QName(b"title") if *in_entry => {
+                Self::read_text_field(reader, e.name(), &mut current.title);
+            }
+            QName(b"content") if *in_entry => {
+                Self::handle_content_element(reader, e, current);
+            }
+            QName(b"im:rating") if *in_entry => {
+                Self::read_numeric_field(reader, e.name(), &mut current.star);
+            }
+            QName(b"im:voteSum") if *in_entry => {
+                Self::read_numeric_field(reader, e.name(), &mut current.like);
+            }
+            QName(b"im:voteCount") if *in_entry => {
+                Self::handle_vote_count(reader, e.name(), current);
+            }
+            QName(b"updated") if *in_entry => {
+                Self::read_text_field(reader, e.name(), &mut current.date);
+            }
+            _ => {}
+        }
+    }
+
+    fn read_text_field(reader: &mut Reader<&[u8]>, name: QName, field: &mut String) {
+        if let Ok(txt) = reader.read_text(name) {
+            *field = txt.to_string();
+        }
+    }
+
+    fn read_numeric_field(reader: &mut Reader<&[u8]>, name: QName, field: &mut i32) {
+        if let Ok(txt) = reader.read_text(name) {
+            *field = txt.parse().unwrap_or(0);
+        }
+    }
+
+    fn handle_content_element(
+        reader: &mut Reader<&[u8]>,
+        e: &quick_xml::events::BytesStart,
+        current: &mut AppStoreReview,
+    ) {
+        // type="text"인 content만
+        if let Some(Attribute { key: _, value: _ }) = e
+            .attributes()
+            .filter_map(Result::ok)
+            .find(|attr| attr.key == QName(b"type") && attr.value.as_ref() == b"text")
+        {
+            Self::read_text_field(reader, e.name(), &mut current.review);
+        }
+    }
+
+    fn handle_vote_count(reader: &mut Reader<&[u8]>, name: QName, current: &mut AppStoreReview) {
+        if let Ok(txt) = reader.read_text(name) {
+            let total: i32 = txt.parse().unwrap_or(0);
+            current.dislike = total.saturating_sub(current.like);
+        }
     }
 }
 

--- a/src/response_processor/play_store.rs
+++ b/src/response_processor/play_store.rs
@@ -37,7 +37,7 @@ impl TStoreType for PlayStoreReview {
 
 impl TExtractData for PlayStoreReview {
     fn extract_data(&self, _response: &[u8]) -> Result<Vec<Self>, CrawlerError> {
-        // TODO: Play Store 리뷰 파싱 로직 구현
+        // TODO: Play Store review parsing not implemented yet
         todo!("Play Store review parsing not implemented yet")
     }
 }

--- a/src/review_crawler/mod.rs
+++ b/src/review_crawler/mod.rs
@@ -2,17 +2,18 @@ use std::sync::OnceLock;
 
 use reqwest::{Client, Response};
 
-use crate::{errors::CrawlerError, review_crawler::traits::TBuildReqeust};
+use crate::errors::CrawlerError;
 
 pub mod app_store;
 pub mod play_store;
-mod traits;
+pub mod traits;
+pub use traits::{HasAppInfo, TBuildRequest};
 
-pub struct Crawler<C: TBuildReqeust> {
+pub struct Crawler<C: TBuildRequest> {
     client: C,
 }
 
-impl<C: TBuildReqeust> Crawler<C> {
+impl<C: TBuildRequest> Crawler<C> {
     pub fn new(client: C) -> Self {
         Self { client }
     }
@@ -34,7 +35,7 @@ impl<C: TBuildReqeust> Crawler<C> {
             responses.push(response);
             self.client.increment_page();
 
-            // 요청 간 짧은 딜레이 추가 (rate limiting 방지)
+            // Add a short delay to avoid rate limiting
             tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
         }
 

--- a/src/review_crawler/play_store.rs
+++ b/src/review_crawler/play_store.rs
@@ -1,7 +1,10 @@
 use reqwest::RequestBuilder;
 use serde::{Deserialize, Serialize};
 
-use crate::review_crawler::{get_client, traits::TBuildReqeust};
+use crate::{
+    review_crawler::{get_client, HasAppInfo, TBuildRequest},
+    GOOGLE_PLAY_MAX_PAGES,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlayStoreClient {
@@ -11,7 +14,16 @@ pub struct PlayStoreClient {
     pub pages: u32,
 }
 
-impl TBuildReqeust for PlayStoreClient {
+impl HasAppInfo for PlayStoreClient {
+    fn app_id(&self) -> &str {
+        &self.app_id
+    }
+    fn country(&self) -> &str {
+        &self.country
+    }
+}
+
+impl TBuildRequest for PlayStoreClient {
     fn build_request(&mut self) -> RequestBuilder {
         // Play Store API endpoint (placeholder - needs actual implementation)
         get_client()
@@ -20,15 +32,12 @@ impl TBuildReqeust for PlayStoreClient {
                 self.country, self.country, self.pages, self.app_id
             ))
     }
-
     fn has_more_pages(&self) -> bool {
-        self.pages <= 100
+        self.pages <= GOOGLE_PLAY_MAX_PAGES
     }
-
     fn increment_page(&mut self) {
         self.pages += 1;
     }
-
     fn get_current_page(&self) -> u32 {
         self.pages
     }
@@ -51,14 +60,14 @@ mod tests {
         assert!(client.has_more_pages());
 
         // Test pagination through all pages (100 for Play Store)
-        for expected_page in 0..=100 {
+        for expected_page in 0..=GOOGLE_PLAY_MAX_PAGES {
             assert_eq!(client.get_current_page(), expected_page);
             assert!(client.has_more_pages());
             client.increment_page();
         }
 
         // After 100 pages, should not have more pages
-        assert_eq!(client.get_current_page(), 101);
+        assert_eq!(client.get_current_page(), GOOGLE_PLAY_MAX_PAGES + 1);
         assert!(!client.has_more_pages());
     }
 

--- a/src/review_crawler/traits.rs
+++ b/src/review_crawler/traits.rs
@@ -1,8 +1,13 @@
 use reqwest::RequestBuilder;
 
-pub trait TBuildReqeust {
+pub trait TBuildRequest {
     fn build_request(&mut self) -> RequestBuilder;
     fn has_more_pages(&self) -> bool;
     fn increment_page(&mut self);
     fn get_current_page(&self) -> u32;
+}
+
+pub trait HasAppInfo {
+    fn app_id(&self) -> &str;
+    fn country(&self) -> &str;
 }


### PR DESCRIPTION
- Extract long read_event match statement into separate helper functions
- Add handle_start_event() to manage XML start element processing
- Create reusable helper functions: read_text_field(), read_numeric_field()
- Add specialized handlers: handle_content_element(), handle_vote_count()
- Improve code maintainability and testability
- Reduce code duplication in XML parsing logic
- Maintain all existing functionality while improving structure